### PR TITLE
Fix Serialization of struct field names

### DIFF
--- a/src/main/java/us/hebi/matlab/mat/format/Mat5WriteUtil.java
+++ b/src/main/java/us/hebi/matlab/mat/format/Mat5WriteUtil.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,21 +20,21 @@
 
 package us.hebi.matlab.mat.format;
 
-import us.hebi.matlab.mat.util.Casts;
 import us.hebi.matlab.mat.types.Array;
 import us.hebi.matlab.mat.types.Opaque;
 import us.hebi.matlab.mat.types.Sink;
+import us.hebi.matlab.mat.util.Casts;
 
 import java.io.IOException;
 import java.nio.CharBuffer;
 import java.util.zip.Deflater;
 
-import static us.hebi.matlab.mat.util.Casts.*;
+import static us.hebi.matlab.mat.format.Mat5Type.*;
 import static us.hebi.matlab.mat.format.Mat5Type.Int32;
 import static us.hebi.matlab.mat.format.Mat5Type.Int8;
-import static us.hebi.matlab.mat.format.Mat5Type.*;
 import static us.hebi.matlab.mat.format.Mat5Type.UInt32;
 import static us.hebi.matlab.mat.types.MatlabType.*;
+import static us.hebi.matlab.mat.util.Casts.*;
 
 /**
  * Static utility methods for serializing custom classes
@@ -69,7 +69,7 @@ public class Mat5WriteUtil {
     public static int computeArrayHeaderSize(String name, Array array) {
         int arrayFlags = UInt32.computeSerializedSize(2);
         int dimensions = Int32.computeSerializedSize(array.getNumDimensions());
-        int nameLen = Int8.computeSerializedSize(name.length()); // ascii
+        int nameLen = Int8.computeSerializedSize(getLimitedNameLength(name)); // ascii
         return arrayFlags + dimensions + nameLen;
     }
 
@@ -88,7 +88,7 @@ public class Mat5WriteUtil {
         Int32.writeIntsWithTag(array.getDimensions(), sink);
 
         // Subfield 3: Name
-        Int8.writeBytesWithTag(name.getBytes(Charsets.US_ASCII), sink);
+        Int8.writeBytesWithTag(getLimitedName(name).getBytes(Charsets.US_ASCII), sink);
     }
 
     public static int computeOpaqueSize(String name, us.hebi.matlab.mat.types.Opaque array) {
@@ -161,6 +161,35 @@ public class Mat5WriteUtil {
 
     }
 
+    /**
+     * MATLAB has a limit for variable names and struct fields of 63 characters (R2018b)
+     * (64 w/ null terminator). If the input name exceeds this limit, the field
+     * name will be truncated and a warning be printed out.
+     * <p>
+     * The limit can be determined via the 'namelengthmax' function. Serializing 63 char
+     * long names was verified in R2018b.
+     *
+     * @param name desired variable name
+     * @return original input or truncated if necessary
+     */
+    static String getLimitedName(String name) {
+        // Name is within bounds
+        if (name.length() <= NAME_LENGTH_MAX)
+            return name;
+
+        // Truncate to max characters and print MATLAB-like warning
+        String truncated = name.substring(0, NAME_LENGTH_MAX);
+        String warning = "Warning: '%s' exceeds MATLAB's maximum name length and will be truncated to '%s'.";
+        System.err.println(String.format(warning, name, truncated));
+        return truncated;
+    }
+
+    static int getLimitedNameLength(String name) {
+        if (name == null) return 0;
+        return Math.min(NAME_LENGTH_MAX, name.length());
+    }
+
+    private static final int NAME_LENGTH_MAX = 63; // Spec says 31, but R2018b supports 63
     private static final int DUMMY_SIZE = 0;
 
 }

--- a/src/main/java/us/hebi/matlab/mat/format/MatStruct.java
+++ b/src/main/java/us/hebi/matlab/mat/format/MatStruct.java
@@ -69,8 +69,7 @@ class MatStruct extends AbstractStruct implements Mat5Serializable {
     protected int getLongestFieldName() {
         int length = 0;
         for (String name : getFieldNames()) {
-            int truncated = Math.min(NAME_LENGTH_MAX, name.length());
-            length = Math.max(length, truncated);
+            length = Math.max(length, getLimitedNameLength(name));
         }
         return length + NULL_TERMINATOR_LENGTH;
     }
@@ -133,7 +132,7 @@ class MatStruct extends AbstractStruct implements Mat5Serializable {
         byte[] ascii = new byte[numChars];
         Arrays.fill(ascii, NULL_TERMINATOR);
         for (int i = 0; i < numFields; i++) {
-            String fieldName = truncatedFieldName(getFieldNames().get(i));
+            String fieldName = getLimitedName(getFieldNames().get(i));
             byte[] bytes = fieldName.getBytes(Charsets.US_ASCII);
             System.arraycopy(bytes, 0, ascii, i * longestName, bytes.length);
         }
@@ -149,30 +148,7 @@ class MatStruct extends AbstractStruct implements Mat5Serializable {
 
     }
 
-    /**
-     * MATLAB has a limit for variable names and struct fields of 63 characters (R2018b)
-     * (64 w/ null terminator). If the input name exceeds this limit, the field
-     * name will be truncated and a warning be printed out.
-     *
-     * The limit can be determined via the 'namelengthmax' function.
-     *
-     * @param fieldName desired variable name
-     * @return original input or truncated if necessary
-     */
-    private static String truncatedFieldName(String fieldName) {
-        // Name is within bounds
-        if (fieldName.length() <= NAME_LENGTH_MAX)
-            return fieldName;
-
-        // Truncate to max characters and print MATLAB-like warning
-        String truncated = fieldName.substring(0, NAME_LENGTH_MAX);
-        String warning = "Warning:\nField name '%s' exceeds the MATLAB maximum name length and will be truncated to '%s'.";
-        System.err.println(String.format(warning, fieldName, truncated));
-        return truncated;
-    }
-
     private static final byte NULL_TERMINATOR = (byte) '\0';
     private static final int NULL_TERMINATOR_LENGTH = 1;
-    private static final int NAME_LENGTH_MAX = 63; // Spec says 31, but R2018b supports 63
 
 }

--- a/src/main/java/us/hebi/matlab/mat/format/MatStruct.java
+++ b/src/main/java/us/hebi/matlab/mat/format/MatStruct.java
@@ -35,10 +35,7 @@ import static us.hebi.matlab.mat.format.Mat5WriteUtil.*;
 import static us.hebi.matlab.mat.util.Preconditions.*;
 
 /**
- * Struct serialization as described in MAT File Format 2018 p1-31. Note that
- * the documentation limits the field names to a maximum length of 31 chars
- * (32 with null terminator), but this seems outdated. The limit in R2018b is
- * 63 chars (64 with null terminator).
+ * Struct serialization as described in MAT File Format 2018 p1-31.
  *
  * @author Florian Enner
  * @since 29 Aug 2018
@@ -72,7 +69,8 @@ class MatStruct extends AbstractStruct implements Mat5Serializable {
     protected int getLongestFieldName() {
         int length = 0;
         for (String name : getFieldNames()) {
-            length = Math.max(length, name.length());
+            int truncated = Math.min(NAME_LENGTH_MAX, name.length());
+            length = Math.max(length, truncated);
         }
         return length + NULL_TERMINATOR_LENGTH;
     }
@@ -135,7 +133,7 @@ class MatStruct extends AbstractStruct implements Mat5Serializable {
         byte[] ascii = new byte[numChars];
         Arrays.fill(ascii, NULL_TERMINATOR);
         for (int i = 0; i < numFields; i++) {
-            String fieldName = getFieldNames().get(i);
+            String fieldName = truncatedFieldName(getFieldNames().get(i));
             byte[] bytes = fieldName.getBytes(Charsets.US_ASCII);
             System.arraycopy(bytes, 0, ascii, i * longestName, bytes.length);
         }
@@ -151,7 +149,30 @@ class MatStruct extends AbstractStruct implements Mat5Serializable {
 
     }
 
+    /**
+     * MATLAB has a limit for variable names and struct fields of 63 characters (R2018b)
+     * (64 w/ null terminator). If the input name exceeds this limit, the field
+     * name will be truncated and a warning be printed out.
+     *
+     * The limit can be determined via the 'namelengthmax' function.
+     *
+     * @param fieldName desired variable name
+     * @return original input or truncated if necessary
+     */
+    private static String truncatedFieldName(String fieldName) {
+        // Name is within bounds
+        if (fieldName.length() <= NAME_LENGTH_MAX)
+            return fieldName;
+
+        // Truncate to max characters and print MATLAB-like warning
+        String truncated = fieldName.substring(0, NAME_LENGTH_MAX);
+        String warning = "Warning:\nField name '%s' exceeds the MATLAB maximum name length and will be truncated to '%s'.";
+        System.err.println(String.format(warning, fieldName, truncated));
+        return truncated;
+    }
+
     private static final byte NULL_TERMINATOR = (byte) '\0';
     private static final int NULL_TERMINATOR_LENGTH = 1;
+    private static final int NAME_LENGTH_MAX = 63; // Spec says 31, but R2018b supports 63
 
 }

--- a/src/main/java/us/hebi/matlab/mat/format/MatStruct.java
+++ b/src/main/java/us/hebi/matlab/mat/format/MatStruct.java
@@ -29,12 +29,17 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import static us.hebi.matlab.mat.util.Preconditions.*;
 import static us.hebi.matlab.mat.format.Mat5.*;
 import static us.hebi.matlab.mat.format.Mat5Type.*;
 import static us.hebi.matlab.mat.format.Mat5WriteUtil.*;
+import static us.hebi.matlab.mat.util.Preconditions.*;
 
 /**
+ * Struct serialization as described in MAT File Format 2018 p1-31. Note that
+ * the documentation limits the field names to a maximum length of 31 chars
+ * (32 with null terminator), but this seems outdated. The limit in R2018b is
+ * 63 chars (64 with null terminator).
+ *
  * @author Florian Enner
  * @since 29 Aug 2018
  */
@@ -69,7 +74,7 @@ class MatStruct extends AbstractStruct implements Mat5Serializable {
         for (String name : getFieldNames()) {
             length = Math.max(length, name.length());
         }
-        return length;
+        return length + NULL_TERMINATOR_LENGTH;
     }
 
     @Override
@@ -128,7 +133,7 @@ class MatStruct extends AbstractStruct implements Mat5Serializable {
 
         // Subfield 5/6: Field Names
         byte[] ascii = new byte[numChars];
-        Arrays.fill(ascii, (byte) '\0');
+        Arrays.fill(ascii, NULL_TERMINATOR);
         for (int i = 0; i < numFields; i++) {
             String fieldName = getFieldNames().get(i);
             byte[] bytes = fieldName.getBytes(Charsets.US_ASCII);
@@ -145,5 +150,8 @@ class MatStruct extends AbstractStruct implements Mat5Serializable {
         }
 
     }
+
+    private static final byte NULL_TERMINATOR = (byte) '\0';
+    private static final int NULL_TERMINATOR_LENGTH = 1;
 
 }

--- a/src/main/java/us/hebi/matlab/mat/types/AbstractStruct.java
+++ b/src/main/java/us/hebi/matlab/mat/types/AbstractStruct.java
@@ -74,7 +74,7 @@ public abstract class AbstractStruct extends AbstractStructBase {
 
     protected Array[] getOrInitValues(String field) {
         // Field exists
-        Integer fieldIndex = indexMap.get(field);
+        Integer fieldIndex = indexMap.get(checkNonEmpty(field));
         if (fieldIndex != null)
             return values.get(fieldIndex);
 


### PR DESCRIPTION
Fixed null termination for struct field names and enforced maximum name limit to avoid files being unloadable in MATLAB.

This fixes #23 

