### PR TITLE
Release 0.3

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,5 +1,10 @@
 = Mat-File IO - Changelog
 
+== 0.3
+* Added `hashCode()` and `equals()` to all Arrays. Thanks `@nedtwigg`
+* Fixed a bug that caused the `global` flag to be ignored during construction. Thanks `@nedtwigg`
+* Fixed a bug that caused field names inside structs and objects to be serialized incorrectly
+
 == 0.2
 * Moved `common.util` to `mat.util`
 * Removed unused utilities

--- a/README.adoc
+++ b/README.adoc
@@ -18,7 +18,7 @@ Mat-File IO is in the Maven central repository and can easily be added to Maven,
 <dependency>
     <groupId>us.hebi.matlab</groupId>
     <artifactId>mat-file-io</artifactId>
-    <version>0.2</version>
+    <version>0.3</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>us.hebi.matlab</groupId>
     <artifactId>mat-file-io</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Mat-File IO</name>

--- a/src/main/java/us/hebi/matlab/mat/format/Compat.java
+++ b/src/main/java/us/hebi/matlab/mat/format/Compat.java
@@ -1,0 +1,38 @@
+/*-
+ * #%L
+ * Mat-File IO
+ * %%
+ * Copyright (C) 2018 HEBI Robotics
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package us.hebi.matlab.mat.format;
+
+import java.util.Arrays;
+
+/**
+ * Backport of java.util.Objects.
+ *
+ * @since 06 Dec 2018
+ */
+public class Compat {
+    public static int hash(Object... values) {
+        return Arrays.hashCode(values);
+    }
+
+    public static boolean equals(Object a, Object b) {
+        return (a == b) || (a != null && a.equals(b));
+    }
+}

--- a/src/main/java/us/hebi/matlab/mat/format/Mat5File.java
+++ b/src/main/java/us/hebi/matlab/mat/format/Mat5File.java
@@ -302,4 +302,18 @@ public class Mat5File extends AbstractMatFile {
 
     private static final String MAT5_IDENTIFIER = "MATLAB 5.0 MAT-file";
 
+    @Override
+    protected int subHashCode() {
+        return Compat.hash(description, subsysOffset, byteOrder, version, reduced);
+    }
+
+    @Override
+    protected boolean subEqualsGuaranteedSameClass(Object otherGuaranteedSameClass) {
+        Mat5File other = (Mat5File) otherGuaranteedSameClass;
+        return Compat.equals(other.description, description) &&
+                Compat.equals(other.subsysOffset, subsysOffset) &&
+                Compat.equals(other.byteOrder, byteOrder) &&
+                Compat.equals(other.version, version) &&
+                Compat.equals(other.reduced, reduced);
+    }
 }

--- a/src/main/java/us/hebi/matlab/mat/format/Mat5Subsystem.java
+++ b/src/main/java/us/hebi/matlab/mat/format/Mat5Subsystem.java
@@ -112,4 +112,14 @@ public final class Mat5Subsystem extends AbstractArray implements Mat5Serializab
     private BufferAllocator bufferAllocator;
     private Mat5File subFile;
 
+    @Override
+    protected int subHashCode() {
+        return buffer.hashCode();
+    }
+
+    @Override
+    protected boolean subEqualsGuaranteedSameClass(Object otherGuaranteedSameClass) {
+        Mat5Subsystem other = (Mat5Subsystem) otherGuaranteedSameClass;
+        return other.buffer.equals(buffer);
+    }
 }

--- a/src/main/java/us/hebi/matlab/mat/format/Mat5WriteUtil.java
+++ b/src/main/java/us/hebi/matlab/mat/format/Mat5WriteUtil.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,21 +20,21 @@
 
 package us.hebi.matlab.mat.format;
 
-import us.hebi.matlab.mat.util.Casts;
 import us.hebi.matlab.mat.types.Array;
 import us.hebi.matlab.mat.types.Opaque;
 import us.hebi.matlab.mat.types.Sink;
+import us.hebi.matlab.mat.util.Casts;
 
 import java.io.IOException;
 import java.nio.CharBuffer;
 import java.util.zip.Deflater;
 
-import static us.hebi.matlab.mat.util.Casts.*;
+import static us.hebi.matlab.mat.format.Mat5Type.*;
 import static us.hebi.matlab.mat.format.Mat5Type.Int32;
 import static us.hebi.matlab.mat.format.Mat5Type.Int8;
-import static us.hebi.matlab.mat.format.Mat5Type.*;
 import static us.hebi.matlab.mat.format.Mat5Type.UInt32;
 import static us.hebi.matlab.mat.types.MatlabType.*;
+import static us.hebi.matlab.mat.util.Casts.*;
 
 /**
  * Static utility methods for serializing custom classes
@@ -69,7 +69,7 @@ public class Mat5WriteUtil {
     public static int computeArrayHeaderSize(String name, Array array) {
         int arrayFlags = UInt32.computeSerializedSize(2);
         int dimensions = Int32.computeSerializedSize(array.getNumDimensions());
-        int nameLen = Int8.computeSerializedSize(name.length()); // ascii
+        int nameLen = Int8.computeSerializedSize(getLimitedNameLength(name)); // ascii
         return arrayFlags + dimensions + nameLen;
     }
 
@@ -88,7 +88,7 @@ public class Mat5WriteUtil {
         Int32.writeIntsWithTag(array.getDimensions(), sink);
 
         // Subfield 3: Name
-        Int8.writeBytesWithTag(name.getBytes(Charsets.US_ASCII), sink);
+        Int8.writeBytesWithTag(getLimitedName(name).getBytes(Charsets.US_ASCII), sink);
     }
 
     public static int computeOpaqueSize(String name, us.hebi.matlab.mat.types.Opaque array) {
@@ -161,6 +161,35 @@ public class Mat5WriteUtil {
 
     }
 
+    /**
+     * MATLAB has a limit for variable names and struct fields of 63 characters (R2018b)
+     * (64 w/ null terminator). If the input name exceeds this limit, the field
+     * name will be truncated and a warning be printed out.
+     * <p>
+     * The limit can be determined via the 'namelengthmax' function. Serializing 63 char
+     * long names was verified in R2018b.
+     *
+     * @param name desired variable name
+     * @return original input or truncated if necessary
+     */
+    static String getLimitedName(String name) {
+        // Name is within bounds
+        if (name.length() <= NAME_LENGTH_MAX)
+            return name;
+
+        // Truncate to max characters and print MATLAB-like warning
+        String truncated = name.substring(0, NAME_LENGTH_MAX);
+        String warning = "Warning: '%s' exceeds MATLAB's maximum name length and will be truncated to '%s'.";
+        System.err.println(String.format(warning, name, truncated));
+        return truncated;
+    }
+
+    static int getLimitedNameLength(String name) {
+        if (name == null) return 0;
+        return Math.min(NAME_LENGTH_MAX, name.length());
+    }
+
+    private static final int NAME_LENGTH_MAX = 63; // Spec says 31, but R2018b supports 63
     private static final int DUMMY_SIZE = 0;
 
 }

--- a/src/main/java/us/hebi/matlab/mat/format/MatCell.java
+++ b/src/main/java/us/hebi/matlab/mat/format/MatCell.java
@@ -68,4 +68,14 @@ class MatCell extends AbstractCell implements Mat5Serializable {
         }
     }
 
+    @Override
+    protected int subHashCode() {
+        return Arrays.hashCode(contents);
+    }
+
+    @Override
+    protected boolean subEqualsGuaranteedSameClass(Object otherGuaranteedSameClass) {
+        MatCell other = (MatCell) otherGuaranteedSameClass;
+        return Arrays.equals(other.contents, contents);
+    }
 }

--- a/src/main/java/us/hebi/matlab/mat/format/MatChar.java
+++ b/src/main/java/us/hebi/matlab/mat/format/MatChar.java
@@ -88,4 +88,14 @@ class MatChar extends AbstractCharBase implements Mat5Serializable {
     protected final CharBuffer buffer;
     protected final CharEncoding encoding;
 
+    @Override
+    protected int subHashCode() {
+        return Compat.hash(buffer, encoding);
+    }
+
+    @Override
+    protected boolean subEqualsGuaranteedSameClass(Object otherGuaranteedSameClass) {
+        MatChar other = (MatChar) otherGuaranteedSameClass;
+        return other.encoding.equals(encoding) && other.buffer.equals(buffer);
+    }
 }

--- a/src/main/java/us/hebi/matlab/mat/format/MatFunction.java
+++ b/src/main/java/us/hebi/matlab/mat/format/MatFunction.java
@@ -68,4 +68,14 @@ class MatFunction extends AbstractArray implements FunctionHandle, Mat5Serializa
 
     final Struct content;
 
+    @Override
+    protected int subHashCode() {
+        return content.hashCode();
+    }
+
+    @Override
+    protected boolean subEqualsGuaranteedSameClass(Object otherGuaranteedSameClass) {
+        MatFunction other = (MatFunction) otherGuaranteedSameClass;
+        return other.content.equals(content);
+    }
 }

--- a/src/main/java/us/hebi/matlab/mat/format/MatMatrix.java
+++ b/src/main/java/us/hebi/matlab/mat/format/MatMatrix.java
@@ -154,4 +154,21 @@ class MatMatrix extends AbstractMatrixBase implements Mat5Serializable {
     private final boolean complex;
     private final MatlabType type;
 
+    @Override
+    protected int subHashCode() {
+        return Compat.hash(logical, complex, type,
+                UniversalNumberStore.hashCodeForType(real, logical, type),
+                UniversalNumberStore.hashCodeForType(imaginary, logical, type));
+    }
+
+    @Override
+    protected boolean subEqualsGuaranteedSameClass(Object otherGuaranteedSameClass) {
+        MatMatrix other = (MatMatrix) otherGuaranteedSameClass;
+        // all the primitive fields have to match before we bother looking at the data
+        return other.logical == logical && 
+                other.complex == complex &&
+                other.type == type &&
+                UniversalNumberStore.equalForType(other.real, real, logical, type) &&
+                UniversalNumberStore.equalForType(other.imaginary, imaginary, logical, type);
+    }
 }

--- a/src/main/java/us/hebi/matlab/mat/format/MatObjectStruct.java
+++ b/src/main/java/us/hebi/matlab/mat/format/MatObjectStruct.java
@@ -52,4 +52,14 @@ class MatObjectStruct extends MatStruct implements ObjectStruct {
 
     private final String className;
 
+    @Override
+    protected int subHashCode() {
+        return 31 * className.hashCode() + super.subHashCode();
+    }
+
+    @Override
+    protected boolean subEqualsGuaranteedSameClass(Object otherGuaranteedSameClass) {
+        MatObjectStruct other = (MatObjectStruct) otherGuaranteedSameClass;
+        return other.className.equals(className) && super.subEqualsGuaranteedSameClass(other);
+    }
 }

--- a/src/main/java/us/hebi/matlab/mat/format/MatOpaque.java
+++ b/src/main/java/us/hebi/matlab/mat/format/MatOpaque.java
@@ -76,4 +76,16 @@ class MatOpaque extends AbstractArray implements Opaque, Mat5Serializable {
     private final Array content;
     private static final int[] SINGLE_DIM = new int[]{1, 1};
 
+    @Override
+    protected int subHashCode() {
+        return Compat.hash(objectType, className, content);
+    }
+
+    @Override
+    protected boolean subEqualsGuaranteedSameClass(Object otherGuaranteedSameClass) {
+        MatOpaque other = (MatOpaque) otherGuaranteedSameClass;
+        return other.objectType.equals(objectType) &&
+                other.className.equals(className) &&
+                other.content.equals(content);
+    }
 }

--- a/src/main/java/us/hebi/matlab/mat/format/MatSparseCSC.java
+++ b/src/main/java/us/hebi/matlab/mat/format/MatSparseCSC.java
@@ -22,6 +22,7 @@ package us.hebi.matlab.mat.format;
 
 import us.hebi.matlab.mat.util.Casts;
 import us.hebi.matlab.mat.types.AbstractSparse;
+import us.hebi.matlab.mat.types.MatlabType;
 import us.hebi.matlab.mat.types.Sink;
 import us.hebi.matlab.mat.types.Sparse;
 
@@ -211,4 +212,25 @@ class MatSparseCSC extends AbstractSparse implements Sparse, Mat5Serializable {
         if (complex) imaginary.writeMat5(sink);
     }
 
+    @Override
+    protected int subHashCode() {
+        return Compat.hash(nzMax, logical, complex,
+                UniversalNumberStore.hashCodeForType(imaginary, logical, MatlabType.Double),
+                UniversalNumberStore.hashCodeForType(real, logical, MatlabType.Double),
+                UniversalNumberStore.hashCodeForType(rowIndices, logical, MatlabType.Int64),
+                UniversalNumberStore.hashCodeForType(columnIndices, logical, MatlabType.Int64));
+    }
+
+    @Override
+    protected boolean subEqualsGuaranteedSameClass(Object otherGuaranteedSameClass) {
+        MatSparseCSC other = (MatSparseCSC) otherGuaranteedSameClass;
+        // all the primitive fields have to match before we bother looking at the data
+        return other.nzMax == nzMax && 
+                other.logical == logical &&
+                other.complex == complex &&
+                UniversalNumberStore.equalForType(other.imaginary, imaginary, logical, MatlabType.Double) &&
+                UniversalNumberStore.equalForType(other.real, real, logical, MatlabType.Double) &&
+                UniversalNumberStore.equalForType(other.rowIndices, rowIndices, logical, MatlabType.Int64) &&
+                UniversalNumberStore.equalForType(other.columnIndices, columnIndices, logical, MatlabType.Int64);
+    }
 }

--- a/src/main/java/us/hebi/matlab/mat/format/MatStruct.java
+++ b/src/main/java/us/hebi/matlab/mat/format/MatStruct.java
@@ -29,12 +29,14 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import static us.hebi.matlab.mat.util.Preconditions.*;
 import static us.hebi.matlab.mat.format.Mat5.*;
 import static us.hebi.matlab.mat.format.Mat5Type.*;
 import static us.hebi.matlab.mat.format.Mat5WriteUtil.*;
+import static us.hebi.matlab.mat.util.Preconditions.*;
 
 /**
+ * Struct serialization as described in MAT File Format 2018 p1-31.
+ *
  * @author Florian Enner
  * @since 29 Aug 2018
  */
@@ -67,9 +69,9 @@ class MatStruct extends AbstractStruct implements Mat5Serializable {
     protected int getLongestFieldName() {
         int length = 0;
         for (String name : getFieldNames()) {
-            length = Math.max(length, name.length());
+            length = Math.max(length, getLimitedNameLength(name));
         }
-        return length;
+        return length + NULL_TERMINATOR_LENGTH;
     }
 
     @Override
@@ -128,9 +130,9 @@ class MatStruct extends AbstractStruct implements Mat5Serializable {
 
         // Subfield 5/6: Field Names
         byte[] ascii = new byte[numChars];
-        Arrays.fill(ascii, (byte) '\0');
+        Arrays.fill(ascii, NULL_TERMINATOR);
         for (int i = 0; i < numFields; i++) {
-            String fieldName = getFieldNames().get(i);
+            String fieldName = getLimitedName(getFieldNames().get(i));
             byte[] bytes = fieldName.getBytes(Charsets.US_ASCII);
             System.arraycopy(bytes, 0, ascii, i * longestName, bytes.length);
         }
@@ -145,5 +147,8 @@ class MatStruct extends AbstractStruct implements Mat5Serializable {
         }
 
     }
+
+    private static final byte NULL_TERMINATOR = (byte) '\0';
+    private static final int NULL_TERMINATOR_LENGTH = 1;
 
 }

--- a/src/main/java/us/hebi/matlab/mat/format/McosObject.java
+++ b/src/main/java/us/hebi/matlab/mat/format/McosObject.java
@@ -81,4 +81,24 @@ class McosObject {
     public String toString() {
         return "'" + getClassName() + "' class";
     }
+
+    @Override
+    public int hashCode() {
+        return Compat.hash(packageName, className, fieldNames, properties);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj instanceof McosObject) {
+            McosObject other = (McosObject) obj;
+            return other.packageName.equals(packageName) &&
+                    other.className.equals(className) &&
+                    other.fieldNames.equals(fieldNames) &&
+                    other.properties.equals(properties);
+        } else {
+            return false;
+        }
+    }
 }

--- a/src/main/java/us/hebi/matlab/mat/format/McosReference.java
+++ b/src/main/java/us/hebi/matlab/mat/format/McosReference.java
@@ -202,4 +202,19 @@ class McosReference extends AbstractStructBase implements ObjectStruct, Opaque, 
     final int classId;
     final McosObject[] objects;
 
+    @Override
+    protected int subHashCode() {
+        return Compat.hash(objectType, className, content, Arrays.hashCode(objectIds), classId, Arrays.hashCode(objects));
+    }
+
+    @Override
+    protected boolean subEqualsGuaranteedSameClass(Object otherGuaranteedSameClass) {
+        McosReference other = (McosReference) otherGuaranteedSameClass;
+        return other.objectType.equals(objectType) &&
+                other.className.equals(className) &&
+                other.classId == classId &&
+                other.content.equals(content) &&
+                Arrays.equals(other.objectIds, objectIds) &&
+                Arrays.equals(other.objects, objects);
+    }
 }

--- a/src/main/java/us/hebi/matlab/mat/format/UniversalNumberStore.java
+++ b/src/main/java/us/hebi/matlab/mat/format/UniversalNumberStore.java
@@ -22,6 +22,7 @@ package us.hebi.matlab.mat.format;
 
 import us.hebi.matlab.mat.util.Bytes;
 import us.hebi.matlab.mat.util.Casts;
+import us.hebi.matlab.mat.types.MatlabType;
 import us.hebi.matlab.mat.types.Sink;
 
 import java.io.IOException;
@@ -212,9 +213,77 @@ class UniversalNumberStore implements NumberStore {
         bufferAllocator = null;
     }
 
-    private final Mat5Type type;
+    final Mat5Type type;
     private final int numElements;
-    private ByteBuffer buffer;
+    ByteBuffer buffer;
     private BufferAllocator bufferAllocator;
 
+    static int hashCodeForType(NumberStore store, boolean logical, MatlabType type) {
+        if (store == null) {
+            return 0;
+        }
+        int hash = 1;
+        if (logical) {
+            for (int i = 0; i < store.getNumElements(); ++i) {
+                hash = 31 * hash + (Casts.logical(store.getDouble(i)) ? 1 : 0);
+            }
+        } else {
+            if (type == MatlabType.Single || type == MatlabType.Double) {
+                for (int i = 0; i < store.getNumElements(); ++i) {
+                    hash = 31 * hash + Double.hashCode(store.getDouble(i));
+                }
+            } else {
+                for (int i = 0; i < store.getNumElements(); ++i) {
+                    hash = 31 * hash + Long.hashCode(store.getLong(i));
+                }
+            }
+        }
+        return hash;
+    }
+
+    static boolean equalForType(NumberStore a, NumberStore b, boolean logical, MatlabType type) {
+        if ((a == null) != (b == null)) {
+            //  null mismatch is easy
+            return false;
+        } else if (a == null) {
+            // they're both null
+            return true;
+        }
+        if (a instanceof UniversalNumberStore && b instanceof UniversalNumberStore) {
+            UniversalNumberStore aCast = (UniversalNumberStore) a;
+            UniversalNumberStore bCast = (UniversalNumberStore) b;
+            if (aCast.type == bCast.type) {
+                // when their types are equal, then their binary content must be exactly the same (much faster)
+                return aCast.buffer.equals(bCast.buffer);
+            }
+        }
+        if (logical) {
+            // compare floating-point types as doubles
+            for (int i = 0; i < a.getNumElements(); ++i) {
+                if (Casts.logical(a.getDouble(i)) != Casts.logical(b.getDouble(i))) {
+                    return false;
+                }
+            }
+        } else {
+            // we need to compare without casting losses, so we need to know if these stores are being used
+            // as floating points or integer types
+            if (type == MatlabType.Single || type == MatlabType.Double) {
+                // compare floating-point types as doubles
+                for (int i = 0; i < a.getNumElements(); ++i) {
+                    if (a.getDouble(i) != b.getDouble(i)) {
+                        return false;
+                    }
+                }
+            } else {
+                // and integer types as ints
+                for (int i = 0; i < a.getNumElements(); ++i) {
+                    if (a.getLong(i) != b.getLong(i)) {
+                        return false;
+                    }
+                }
+            }
+        }
+        // same number of elements and numeric values, so they're equal
+        return true;
+    }
 }

--- a/src/main/java/us/hebi/matlab/mat/types/AbstractArray.java
+++ b/src/main/java/us/hebi/matlab/mat/types/AbstractArray.java
@@ -22,6 +22,8 @@ package us.hebi.matlab.mat.types;
 
 import static us.hebi.matlab.mat.util.Preconditions.*;
 
+import java.util.Arrays;
+
 /**
  * @author Florian Enner
  * @since 02 May 2018
@@ -115,6 +117,7 @@ public abstract class AbstractArray implements Array {
         this.dims = checkNotNull(dims);
         checkArgument(dims.length >= 2, "Every array must have at least two dimensions");
         this.dimStrides = calculateColMajorStrides(dims);
+        this.isGlobal = isGlobal;
     }
 
     @Override
@@ -129,4 +132,33 @@ public abstract class AbstractArray implements Array {
     // Internal state
     private final int[] dimStrides;
 
+    @Override
+    public final int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Arrays.hashCode(dims);
+        result = prime * result + (isGlobal ? 1231 : 1237);
+        result = prime * result + subHashCode();
+        return result;
+    }
+
+    @Override
+    public final boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        } else if (other == null) {
+            return false;
+        } else if (other.getClass().equals(this.getClass())) {
+            AbstractArray otherArray = (AbstractArray) other;
+            return otherArray.isGlobal == isGlobal &&
+                    Arrays.equals(otherArray.dims, dims) &&
+                    subEqualsGuaranteedSameClass(other);
+        } else {
+            return false;
+        }
+    }
+
+    protected abstract int subHashCode();
+
+    protected abstract boolean subEqualsGuaranteedSameClass(Object otherGuaranteedSameClass);
 }

--- a/src/main/java/us/hebi/matlab/mat/types/AbstractMatFile.java
+++ b/src/main/java/us/hebi/matlab/mat/types/AbstractMatFile.java
@@ -111,4 +111,26 @@ public abstract class AbstractMatFile extends AbstractMatFileBase {
     protected final HashMap<String, Array> lookup = new HashMap<String, Array>();
     protected final List<NamedArray> entries = new ArrayList<NamedArray>();
 
+    @Override
+    public final int hashCode() {
+        return 31 * subHashCode() + entries.hashCode();
+    }
+
+    @Override
+    public final boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        } else if (other == null) {
+            return false;
+        } else if (other.getClass().equals(this.getClass())) {
+            AbstractMatFile otherFile = (AbstractMatFile) other;
+            return subEqualsGuaranteedSameClass(other) && otherFile.entries.equals(entries);
+        } else {
+            return false;
+        }
+    }
+
+    protected abstract int subHashCode();
+
+    protected abstract boolean subEqualsGuaranteedSameClass(Object otherGuaranteedSameClass);
 }

--- a/src/main/java/us/hebi/matlab/mat/types/AbstractStruct.java
+++ b/src/main/java/us/hebi/matlab/mat/types/AbstractStruct.java
@@ -74,7 +74,7 @@ public abstract class AbstractStruct extends AbstractStructBase {
 
     protected Array[] getOrInitValues(String field) {
         // Field exists
-        Integer fieldIndex = indexMap.get(field);
+        Integer fieldIndex = indexMap.get(checkNonEmpty(field));
         if (fieldIndex != null)
             return values.get(fieldIndex);
 
@@ -111,4 +111,32 @@ public abstract class AbstractStruct extends AbstractStructBase {
     private final List<String> fields = new ArrayList<String>();
     private final List<Array[]> values = new ArrayList<Array[]>();
 
+    @Override
+    protected int subHashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + indexMap.hashCode();
+        result = prime * result + fields.hashCode();
+        for (Array[] valueArray : values) {
+            result = prime * result + Arrays.hashCode(valueArray);
+        }
+        return result;
+    }
+
+    @Override
+    protected boolean subEqualsGuaranteedSameClass(Object otherGuaranteedSameClass) {
+        AbstractStruct other = (AbstractStruct) otherGuaranteedSameClass;
+        if (other.indexMap.equals(indexMap) &&
+                other.fields.equals(fields) &&
+                other.values.size() == values.size()) {
+            for (int i = 0; i < values.size(); ++i) {
+                if (!Arrays.equals(other.values.get(i), values.get(i))) {
+                    return false;
+                }
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
 }

--- a/src/main/java/us/hebi/matlab/mat/types/NamedArray.java
+++ b/src/main/java/us/hebi/matlab/mat/types/NamedArray.java
@@ -56,4 +56,20 @@ public final class NamedArray {
     private final String name;
     private final Array value;
 
+    @Override
+    public int hashCode() {
+        return 31 * name.hashCode() + value.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj instanceof NamedArray) {
+            NamedArray other = (NamedArray) obj;
+            return other.name.equals(name) && other.value.equals(value);
+        } else {
+            return false;
+        }
+    }
 }

--- a/src/test/java/us/hebi/matlab/mat/tests/mat5/ArrayReadTest.java
+++ b/src/test/java/us/hebi/matlab/mat/tests/mat5/ArrayReadTest.java
@@ -47,6 +47,16 @@ public class ArrayReadTest {
     }
 
     @Test
+    public void testReadingNaNEquality() throws Exception {
+        Matrix real = MatTestUtil.readMat("arrays/nan.mat").getMatrix("x");
+        Matrix realChanged = MatTestUtil.readMat("arrays/nan.mat").getMatrix("x");
+        realChanged.setDouble(0, 5.0);
+        assertNotEquals("When the value has changed, they should not be equal.", real, realChanged);
+        real.setDouble(0, 5.0);
+        assertEquals("But when they are the same, they should not be equal again.", real, realChanged);
+    }
+
+    @Test
     public void testSingle() throws Exception {
         Matrix real = MatTestUtil.readMat("arrays/single.mat").getMatrix("arr");
         assertEquals(MatlabType.Single, real.getType());

--- a/src/test/java/us/hebi/matlab/mat/tests/mat5/MatTestUtil.java
+++ b/src/test/java/us/hebi/matlab/mat/tests/mat5/MatTestUtil.java
@@ -53,6 +53,10 @@ public class MatTestUtil {
     }
 
     public static Mat5File readMat(String name, boolean testRoundTrip, boolean reduced) throws IOException {
+        return readMat(name, testRoundTrip, reduced, true);
+    }
+
+    public static Mat5File readMat(String name, boolean testRoundTrip, boolean reduced, boolean equalityCheck) throws IOException {
         // Read from original file using single-threaded reader
         Mat5File resultMat = readMat(MatTestUtil.class, name, reduced);
         if (debugPrint) {
@@ -60,6 +64,13 @@ public class MatTestUtil {
             for (NamedArray result : resultMat.getEntries()) {
                 System.out.println(result);
             }
+        }
+
+        // Assert that equality is working
+        if (equalityCheck) {
+            Mat5File secondLoad = readMat(MatTestUtil.class, name, reduced);
+            assertEquals("Loading the file a second time should be equal to the first load", resultMat, secondLoad);
+            assertEquals("Loading the file a second time should have the same hash as the first load", resultMat.hashCode(), secondLoad.hashCode());
         }
 
         if (!testRoundTrip)

--- a/src/test/java/us/hebi/matlab/mat/tests/mat5/SimulinkTest.java
+++ b/src/test/java/us/hebi/matlab/mat/tests/mat5/SimulinkTest.java
@@ -41,7 +41,11 @@ public class SimulinkTest {
      */
     @Test
     public void testParsingQuadraticRootsTET() throws Exception {
-        Mat5File mat = MatTestUtil.readMat("simulink/simulink_tet_out.mat", true, true);
+        // the object graph is not hierarchical or even a DAG.
+        // it is a cyclic graph which causes StackOverflow on equality check
+        // rare enough that it's not clear how much investigation is warranted...
+        boolean equalityCheck = false;
+        Mat5File mat = MatTestUtil.readMat("simulink/simulink_tet_out.mat", true, true, equalityCheck);
 
         // First check that the root element is correct.
         final ObjectStruct data = mat.getObject(0); // has no name

--- a/src/test/java/us/hebi/matlab/mat/tests/serialization/EjmlDMatrixWrapper.java
+++ b/src/test/java/us/hebi/matlab/mat/tests/serialization/EjmlDMatrixWrapper.java
@@ -78,4 +78,14 @@ public class EjmlDMatrixWrapper extends AbstractArray implements Mat5Serializabl
 
     final DMatrix matrix;
 
+    @Override
+    protected int subHashCode() {
+        return matrix.hashCode();
+    }
+
+    @Override
+    protected boolean subEqualsGuaranteedSameClass(Object otherGuaranteedSameClass) {
+        EjmlDMatrixWrapper other = (EjmlDMatrixWrapper) otherGuaranteedSameClass;
+        return other.matrix.equals(matrix);
+    }
 }

--- a/src/test/java/us/hebi/matlab/mat/tests/serialization/EjmlSparseWrapper.java
+++ b/src/test/java/us/hebi/matlab/mat/tests/serialization/EjmlSparseWrapper.java
@@ -120,4 +120,14 @@ public class EjmlSparseWrapper extends AbstractArray implements Mat5Serializable
 
     final DMatrixSparseCSC sparse;
 
+    @Override
+    protected int subHashCode() {
+        return sparse.hashCode();
+    }
+
+    @Override
+    protected boolean subEqualsGuaranteedSameClass(Object otherGuaranteedSameClass) {
+        EjmlSparseWrapper other = (EjmlSparseWrapper) otherGuaranteedSameClass;
+        return other.sparse.equals(sparse);
+    }
 }

--- a/src/test/java/us/hebi/matlab/mat/tests/serialization/StreamingDoubleMatrix2D.java
+++ b/src/test/java/us/hebi/matlab/mat/tests/serialization/StreamingDoubleMatrix2D.java
@@ -164,4 +164,13 @@ public final class StreamingDoubleMatrix2D extends AbstractArray implements Mat5
     final Sink[] columnSinks;
     private final String name;
 
+    @Override
+    protected int subHashCode() {
+        return System.identityHashCode(this);
+    }
+
+    @Override
+    protected boolean subEqualsGuaranteedSameClass(Object otherGuaranteedSameClass) {
+        return false;
+    }
 }


### PR DESCRIPTION
* Added `hashCode()` and `equals()` to all Arrays. Thanks @nedtwigg
* Fixed a bug that caused the `global` flag to be ignored during construction. Thanks @nedtwigg
* Fixed a bug that caused field names inside structs and objects to be serialized incorrectly