### PR TITLE
MatChar equality is now based only on character content

### DIFF
--- a/src/main/java/us/hebi/matlab/mat/format/MatChar.java
+++ b/src/main/java/us/hebi/matlab/mat/format/MatChar.java
@@ -96,6 +96,6 @@ class MatChar extends AbstractCharBase implements Mat5Serializable {
     @Override
     protected boolean subEqualsGuaranteedSameClass(Object otherGuaranteedSameClass) {
         MatChar other = (MatChar) otherGuaranteedSameClass;
-        return other.encoding.equals(encoding) && other.buffer.equals(buffer);
+        return other.buffer.equals(buffer);
     }
 }


### PR DESCRIPTION
Possible resolution of #21 

I think it was smart to separate the peculiarities of MATLAB's fileformat vs the actual semantic data in the `format` vs `types` package as you have done.  `format.CharEncoding` really is Mat5 specific - I hadn't realized the issues around endian-ness and 16-bit ASCII.  Because it's Mat5 specific, I don't think it makes sense to move it to `types`, which means we can't really add it to `Char` either.

What do you think about this little cheat?